### PR TITLE
move initialization to libraries

### DIFF
--- a/packages/contracts/script/PostDeploy.s.sol
+++ b/packages/contracts/script/PostDeploy.s.sol
@@ -11,6 +11,8 @@ import { registerERC20 } from "@latticexyz/world-modules/src/modules/erc20-puppe
 import { ERC20MetadataData } from "@latticexyz/world-modules/src/modules/erc20-puppet/tables/ERC20Metadata.sol";
 
 import { IWorld } from "../src/codegen/world/IWorld.sol";
+import { LibInit } from "../src/libraries/init/LibInit.sol";
+import { LibInitRecipes } from "../src/libraries/init/LibInitRecipes.sol";
 
 uint256 constant POOL_SUPPLY = 1_000_000 wei;
 
@@ -39,10 +41,9 @@ contract PostDeploy is Script {
     token.mint(worldAddress, POOL_SUPPLY);
 
     // Initialize gameConfig, tutorial levels and goals
-    // world.init(worldAddress);
-    world.init(address(token));
+    LibInit.init(address(token));
     // Initialize recipes
-    world.init2();
+    LibInitRecipes.init();
 
     vm.stopBroadcast();
   }

--- a/packages/contracts/src/codegen/world/IWorld.sol
+++ b/packages/contracts/src/codegen/world/IWorld.sol
@@ -6,8 +6,6 @@ pragma solidity >=0.8.24;
 import { IBaseWorld } from "@latticexyz/world/src/codegen/interfaces/IBaseWorld.sol";
 
 import { IWarpSystem } from "./IWarpSystem.sol";
-import { IInit2System } from "./IInit2System.sol";
-import { IInitSystem } from "./IInitSystem.sol";
 import { IBuildSystem } from "./IBuildSystem.sol";
 import { IConnectSystem } from "./IConnectSystem.sol";
 import { IDestroySystem } from "./IDestroySystem.sol";
@@ -29,8 +27,6 @@ import { IStartSystem } from "./IStartSystem.sol";
 interface IWorld is
   IBaseWorld,
   IWarpSystem,
-  IInit2System,
-  IInitSystem,
   IBuildSystem,
   IConnectSystem,
   IDestroySystem,

--- a/packages/contracts/src/libraries/init/LibInit.sol
+++ b/packages/contracts/src/libraries/init/LibInit.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
-import { System } from "@latticexyz/world/src/System.sol";
 import { GameConfig, GameConfigData, TutorialOrders } from "../../codegen/index.sol";
-import { LibOrder } from "../../libraries/Libraries.sol";
+import { LibOrder } from "../LibOrder.sol";
 import { MATERIAL_TYPE } from "../../codegen/common.sol";
 
-contract InitSystem is System {
-  function init(address tokenAddress) public {
+library LibInit {
+  function init(address tokenAddress) internal {
     require(GameConfig.get().tokenAddress == address(0), "InitSystem: already initialized");
 
     // Set game config

--- a/packages/contracts/src/libraries/init/LibInit.sol
+++ b/packages/contracts/src/libraries/init/LibInit.sol
@@ -6,8 +6,6 @@ import { MATERIAL_TYPE } from "../../codegen/common.sol";
 
 library LibInit {
   function init(address tokenAddress) internal {
-    require(GameConfig.get().tokenAddress == address(0), "InitSystem: already initialized");
-
     // Set game config
     GameConfig.set(GameConfigData({ tokenAddress: tokenAddress, globalSpawnIndex: 0 }));
 

--- a/packages/contracts/src/libraries/init/LibInitRecipes.sol
+++ b/packages/contracts/src/libraries/init/LibInitRecipes.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
-import { System } from "@latticexyz/world/src/System.sol";
 import { Recipe } from "../../codegen/index.sol";
-import { LibUtils } from "../../libraries/Libraries.sol";
+import { LibUtils } from "../LibUtils.sol";
 import { MACHINE_TYPE, MATERIAL_TYPE } from "../../codegen/common.sol";
 
-contract Init2System is System {
-  function init2() public {
+library LibInitRecipes {
+  function init() internal {
     // Cooler recipes
     Recipe.set(MACHINE_TYPE.COOLER, uint256(MATERIAL_TYPE.CSX_INDUSTRIAL_GREASE), MATERIAL_TYPE.PURE_FAT);
 


### PR DESCRIPTION
- simplifies the world interface
- removes potential double-initialization issues (the `require` in LibInit is no longer needed)
- allows initializers to be as large as needed, they can be split by logic, not code size