### PR TITLE
encapsulate build index logic

### DIFF
--- a/packages/contracts/src/libraries/LibPod.sol
+++ b/packages/contracts/src/libraries/LibPod.sol
@@ -25,7 +25,7 @@ library LibPod {
    * @param _machineType The type of machine being used.
    * @return buildIndexEntity The identifier for the fetched or newly created build index entity.
    */
-  function getBuildIndexEntity(bytes32 _podEntity, MACHINE_TYPE _machineType) internal returns (bytes32) {
+  function _getBuildIndexEntity(bytes32 _podEntity, MACHINE_TYPE _machineType) private returns (bytes32) {
     QueryFragment[] memory fragments = new QueryFragment[](3);
     fragments[0] = QueryFragment(
       QueryType.HasValue,
@@ -46,5 +46,26 @@ library LibPod {
       BuildIndex.set(buildIndexEntity, 0);
       return buildIndexEntity;
     }
+  }
+
+  /**
+   * @dev Increments global (for all machines in the pod) build index, and sets it for the given machine
+   *
+   * @param _podEntity The identifier for the pod entity.
+   * @param _machineType The type of machine being used.
+   * @param _machineEntity The identifier for the machine entity.
+   */
+  function setMachineBuildIndex(bytes32 _podEntity, MACHINE_TYPE _machineType, bytes32 _machineEntity) internal {
+    // Get build index entity
+    bytes32 buildIndexEntity = _getBuildIndexEntity(_podEntity, _machineType);
+
+    // Increment
+    uint32 newBuildIndex = BuildIndex.get(buildIndexEntity) + 1;
+
+    // Set build index on machine
+    BuildIndex.set(_machineEntity, newBuildIndex);
+
+    // Set global build index
+    BuildIndex.set(buildIndexEntity, newBuildIndex);
   }
 }

--- a/packages/contracts/src/systems/machine-network/BuildSystem.sol
+++ b/packages/contracts/src/systems/machine-network/BuildSystem.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 import { System } from "@latticexyz/world/src/System.sol";
-import { CarriedBy, BuildIndex, MachinesInPod } from "../../codegen/index.sol";
+import { CarriedBy, MachinesInPod } from "../../codegen/index.sol";
 import { MACHINE_TYPE, ENTITY_TYPE } from "../../codegen/common.sol";
 import { LibUtils, LibEntity, LibPod } from "../../libraries/Libraries.sol";
 
@@ -27,17 +27,8 @@ contract BuildSystem is System {
     // Add it to the list of machines
     MachinesInPod.push(podEntity, machineEntity);
 
-    // Get build index entity
-    bytes32 buildIndexEntity = LibPod.getBuildIndexEntity(podEntity, _machineType);
-
-    // Increment
-    uint32 newBuildIndex = BuildIndex.get(buildIndexEntity) + 1;
-
-    // Set build index on machine
-    BuildIndex.set(machineEntity, newBuildIndex);
-
-    // Set global build index
-    BuildIndex.set(buildIndexEntity, newBuildIndex);
+    // Set global and machine-specific build indexes
+    LibPod.setMachineBuildIndex(podEntity, _machineType, machineEntity);
 
     return machineEntity;
   }


### PR DESCRIPTION
`getBuildIndexEntity` is a complicated function which seemed unnecessarily externalized

Feel free to edit this, especially the comments, to match your preferred style, maybe to explain `setMachineBuildIndex` side-effects more
