### PR TITLE
mud-test-gas-report

### DIFF
--- a/packages/contracts/gas-report.json
+++ b/packages/contracts/gas-report.json
@@ -1,0 +1,8 @@
+[
+  {
+    "file": "test/systems/machine-network/ConnectSystem.t.sol",
+    "test": "testConnect",
+    "name": "Connect player to splitter",
+    "gasUsed": 113444
+  }
+]

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -7,6 +7,7 @@
     "clean": "forge clean && rimraf src/codegen",
     "deploy:local": "pnpm run build && mud deploy",
     "dev": "pnpm mud dev-contracts",
+    "mud-test-gas-report": "GAS_REPORTER_ENABLED=true mud test | pnpm gas-report --stdin --save gas-report.json",
     "lint": "pnpm run prettier && pnpm run solhint",
     "prettier": "prettier --write 'src/**/*.sol'",
     "solhint": "solhint --config ./.solhint.json 'src/**/*.sol' --fix",

--- a/packages/contracts/test/BaseTest.sol
+++ b/packages/contracts/test/BaseTest.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Test.sol";
 
+import { GasReporter } from "@latticexyz/gas-report/src/GasReporter.sol";
+
 import { MudTest } from "@latticexyz/world/test/MudTest.t.sol";
 import { ROOT_NAMESPACE, ROOT_NAMESPACE_ID } from "@latticexyz/world/src/constants.sol";
 import { NamespaceOwner } from "@latticexyz/world/src/codegen/tables/NamespaceOwner.sol";
@@ -10,7 +12,7 @@ import { IWorld } from "../src/codegen/world/IWorld.sol";
 
 import "../src/codegen/index.sol";
 
-contract BaseTest is MudTest {
+contract BaseTest is MudTest, GasReporter {
   IWorld world;
   GameConfigData gameConfig;
 

--- a/packages/contracts/test/systems/machine-network/ConnectSystem.t.sol
+++ b/packages/contracts/test/systems/machine-network/ConnectSystem.t.sol
@@ -18,7 +18,9 @@ contract ConnectSystemTest is BaseTest {
     bytes32 splitterEntity = world.build(MACHINE_TYPE.SPLITTER);
 
     // Connect player (first output == piss) to splitter
+    startGasReport("Connect player to splitter");
     world.connect(playerEntity, splitterEntity, PORT_INDEX.FIRST);
+    endGasReport();
 
     vm.stopPrank();
 


### PR DESCRIPTION
`mud-test-gas-report` is a verbose command to avoid shadowing/recursing the internal `gas-report`
feel free to name it something shorter

the idea is to run it after any gas-relevant changes, MUD has a CI check for this too, so we don't forget to run it