### PR TITLE
use static _world, mud's IERC20

### DIFF
--- a/packages/contracts/src/libraries/LibToken.sol
+++ b/packages/contracts/src/libraries/LibToken.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 import { TutorialLevel, EntityType, MachineType, OutgoingConnections, IncomingConnections, GameConfig } from "../codegen/index.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { WorldContextConsumerLib } from "@latticexyz/world/src/WorldContext.sol";
 import { IBaseWorld } from "@latticexyz/world/src/codegen/interfaces/IBaseWorld.sol";
 import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 import { WorldResourceIdInstance } from "@latticexyz/world/src/WorldResourceId.sol";
+import { IERC20 } from "@latticexyz/world-modules/src/modules/erc20-puppet/IERC20.sol";
 import { _balancesTableId } from "@latticexyz/world-modules/src/modules/erc20-puppet/utils.sol";
 import { Balances } from "@latticexyz/world-modules/src/modules/tokens/tables/Balances.sol";
 import { Puppet } from "@latticexyz/world-modules/src/modules/puppet/Puppet.sol";
@@ -34,12 +35,13 @@ library LibToken {
   /**
    * @dev Transfer tokens from the caller to another address
    */
-  function transferToken(address worldAddress, address to, uint256 value) internal {
+  function transferToken(address to, uint256 value) internal {
     address token = GameConfig.getTokenAddress();
     ResourceId systemId = Puppet(token).systemId();
 
     bytes memory callData = abi.encodeCall(IERC20.transfer, (to, value));
 
+    address worldAddress = WorldContextConsumerLib._world();
     (bool success, ) = worldAddress.delegatecall(abi.encodeCall(IBaseWorld(worldAddress).call, (systemId, callData)));
 
     require(success, "token transfer failed");

--- a/packages/contracts/src/systems/order/OfferSystem.sol
+++ b/packages/contracts/src/systems/order/OfferSystem.sol
@@ -27,7 +27,7 @@ contract OfferSystem is System {
     // Get player's pod entity
     bytes32 podEntity = CarriedBy.get(playerEntity);
 
-    LibToken.transferToken(_world(), _world(), offerData.cost);
+    LibToken.transferToken(_world(), offerData.cost);
 
     bytes32[] memory depotsInPod = DepotsInPod.get(podEntity);
 

--- a/packages/contracts/src/systems/progression/RewardSystem.sol
+++ b/packages/contracts/src/systems/progression/RewardSystem.sol
@@ -13,6 +13,6 @@ contract RewardSystem is System {
   // Just used for testing
   function charge() public {
     require(LibToken.getTokenBalance(_msgSender()) >= 100, "insufficient balance");
-    LibToken.transferToken(_world(), _world(), 100);
+    LibToken.transferToken(_world(), 100);
   }
 }


### PR DESCRIPTION
I assume `transferToken` shouldn't have `worldAddress` (since no other function is world-agnostic), and you didn't know about WorldContextConsumerLib

Regarding IERC20 - it feels weird to use OZ for it, when MUD provides the implementation and also has the interface